### PR TITLE
Do not remove conda-meta/history because it breaks caching

### DIFF
--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -55,7 +55,7 @@ cache:
 
 before_cache:
 - if ! [[ $TRAVIS_TAG ]]; then rm -rf $HOME/miniconda/conda-bld; fi
-- rm -rf $HOME/miniconda/locks $HOME/miniconda/pkgs $HOME/miniconda/var $HOME/miniconda/conda-meta/history
+- rm -rf $HOME/miniconda/locks $HOME/miniconda/pkgs $HOME/miniconda/var
 - pip uninstall -y cardboardlint # Cardboardlint always installs even if no changes are made.
 
 branches:


### PR DESCRIPTION
Example: https://travis-ci.com/theochem/grid/jobs/173765179
Code in conda that checks for history file: https://github.com/conda/conda/commit/063cb2f5bf2191320e539687fed9d76f1beec83b#diff-34bb8d01f991a5ffabae5e80b987c83fR157